### PR TITLE
convert output of .geowarp_simulate_vecchia to matrix

### DIFF
--- a/R/simulation.R
+++ b/R/simulation.R
@@ -137,5 +137,5 @@ geowarp_simulate <- function(
     t(U),
     matrix(rnorm(n_samples * nrow(U)), ncol = n_samples)
   )
-  output[Matrix::invPerm(parent_structure$observed_ordering), ]
+  as.matrix(output[Matrix::invPerm(parent_structure$observed_ordering), ])
 }

--- a/inst/examples/02-fit-3d.R
+++ b/inst/examples/02-fit-3d.R
@@ -337,3 +337,7 @@ ggplot() +
   scale_fill_viridis_c() +
   coord_fixed() +
   facet_wrap(~ z)
+
+# Simulate from the fitted model
+simulated_df <- geowarp_simulate(fit, n_samples = 2, vecchia = TRUE)
+str(simulated_df)

--- a/tests/testthat/test-simulate.R
+++ b/tests/testthat/test-simulate.R
@@ -51,7 +51,11 @@ test_that('simulation works', {
 
   result <- call_simulate(n_sample = 1, vecchia = TRUE)
   base_checks(result)
-  expect_type(result$value, 'double')
+  expect_type(result$value, "double")
+  
+  result <- call_simulate(n_sample = 5, vecchia = TRUE)
+  base_checks(result)
+  expect_equal(dim(result$value), c(nrow(target_df), 5))
 
   result <- call_simulate(n_sample = 1, vecchia = TRUE, threads = 2L)
   base_checks(result)


### PR DESCRIPTION
Hi Michael,

I spotted a bug when simulating multiple samples with `.geowarp_simulate_vecchia`. The `tibble` package couldn't handle the output from the `Matrix` package. I converted the output to a `matrix` and added an example at the end of `02-fit-3d.R`.